### PR TITLE
new syntax highlight inspired from rust

### DIFF
--- a/syntaxes/carbon.tmGrammar.json
+++ b/syntaxes/carbon.tmGrammar.json
@@ -1,152 +1,743 @@
 {
-    "scopeName": "source.carbon",
-    "name": "carbon",
-    "fileTypes": [
-        "carbon"
-    ],
-    "patterns": [
-        {
-            "include": "#keywords"
-        },
-        {
-            "include": "#strings"
-        },
-        {
-            "include": "#declarations"
-        },
-        {
-            "include": "#comments"
-        },
-        {
-            "include": "#constants"
-        },
-        {
-            "include": "dataTypes"
-        }
-    ],
-    "repository": {
-        "keywords": {
-            "patterns": [
-                {
-                    "match": "\\b(if|then|else|while|for|in|as|break|return|var|let|match|case|constraint|addr)\\b",
-                    "name": "keyword.control.carbon"
-                },
-                {
-                    "match": "\\b(fn|impl|class|interface|choice)\\b",
-                    "name": "keyword.storage.carbon"
-                },
-                {
-                    "match": "\\b(__continuation|__run|__await)\\b",
-                    "name": "keyword.experimental.carbon"
-                },
-                {
-                    "match": "\\b(base|abstract|virtual|protected|destructor|namespace|private)\\b",
-                    "name": "keyword.WIP.carbon"
-                },
-                {
-                    "match": "\\b(import|package|library|api|alias|external|where|returned|library|and|addr)\\b",
-                    "name": "keyword.other.carbon"
-                }
-            ]
-        },
-        "comments": {
-            "patterns": [
-                {
-                    "begin": "//",
-                    "end": "\\n",
-                    "name": "comment.block.empty.tpl"
-                }
-            ]
-        },
-        "strings": {
-            "name": "string.quoted.double.carbon",
-            "begin": "\"",
-            "end": "\"",
-            "patterns": [
-                {
-                    "name": "constant.character.escape.carbon",
-                    "match": "\\\\."
-                }
-            ]
-        },
-        "constants": {
-            "patterns": [
-                {
-                    "match": "\\b(true|false)\\b",
-                    "name": "constant.bool.carbon"
-                },
-                {
-                    "match": "\\b(0[xX][0-9a-fA-F_]*)\\b",
-                    "name": "constant.numeric.hex.carbon"
-                },
-                {
-                    "match": "\\b(([0-9][0-9_]*(\\.[0-9][0-9_]*)?)([eE](\\+|-)?[0-9][0-9_]*)?|[0-9][0-9_]*)[LlFfDd]?\\b",
-                    "name": "constant.numeric.common.carbon"
-                },
-                {
-                    "match": "(\\.[0-9][0-9_]*)([eE](\\+|-)?[0-9][0-9_]*)?[LlFfDd]?\\b",
-                    "name": "constant.numeric.float.carbon"
-                },
-                {
-                    "match": "\\b(null)\\b",
-                    "name": "constant.other.carbon"
-                }
-            ]
-        },
-        "dataTypes": {
-            "patterns": [
-                {
-                    "match": "\\b(i8,i16,i32,i64,i128,i256,u8,u16,u32,u64,u128)\\b",
-                    "name": "dataTypes.int.carbon"
-                },
-                {
-                    "match": "\\b(String,StringView)\\b",
-                    "name": "dataTypes.string.carbon"
-                }
-            ]
-        },
-        "declarations": {
-            "patterns": [
-              {
-                "name": "keyword.declaration.namespace.carbon",
-                "match": "\\bnamespace\\b"
-              },
-              {
-                "name": "variable.other.carbon",
-                "match": "\\bvar\\b\\s+\\w+",
-                "captures": {
-                  "0": {
-                    "name": "keyword.declaration.variable.carbon"
-                  }
-                }
-              },
-              {
-                "name": "variable.other.carbon",
-                "match": "\\breturned\\b",
-                "captures": {
-                  "0": {
-                    "name": "keyword.modifier.variable.carbon"
-                  }
-                }
-              },
-              {
-                "name": "variable.other.constant.carbon",
-                "match": "\\blet\\b\\s+\\w+",
-                "captures": {
-                  "0": {
-                    "name": "keyword.declaration.constant.carbon"
-                  }
-                }
-              },
-              {
-                "name": "keyword.declaration.function.carbon",
-                "match": "\\bfn\\b"
-              },
-              {
-                "name": "keyword.declaration.class.carbon",
-                "match": "\\bclass\\b\\s+\\w+"
-              }
-            ]
-          }
+  "name": "carbon",
+  "fileTypes": [
+    "carbon"
+  ],
+  "scopeName": "source.carbon",
+  "patterns": [
+    {
+      "include": "#block-comments"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#functions"
+    },
+    {
+      "include": "#types"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#namespaces"
+    },
+    {
+      "include": "#punctuation"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#variables"
     }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "comment": "documentation comments",
+          "name": "comment.line.documentation.carbon",
+          "match": "^\\s*///.*"
+        },
+        {
+          "comment": "line comments",
+          "name": "comment.line.double-slash.carbon",
+          "match": "\\s*//.*"
+        }
+      ]
+    },
+    "block-comments": {
+      "patterns": [
+        {
+          "comment": "empty block comments",
+          "name": "comment.block.carbon",
+          "match": "/\\*\\*/"
+        },
+        {
+          "comment": "block documentation comments",
+          "name": "comment.block.documentation.carbon",
+          "begin": "/\\*\\*",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            }
+          ]
+        },
+        {
+          "comment": "block comments",
+          "name": "comment.block.carbon",
+          "begin": "/\\*(?!\\*)",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "include": "#block-comments"
+            }
+          ]
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "comment": "ALL CAPS constants",
+          "name": "constant.other.caps.carbon",
+          "match": "\\b[A-Z]{2}[A-Z0-9_]*\\b"
+        },
+        {
+          "comment": "constant declarations",
+          "match": "\\b(const)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.carbon"
+            },
+            "2": {
+              "name": "constant.other.caps.carbon"
+            }
+          }
+        },
+        {
+          "comment": "decimal integers and floats",
+          "name": "constant.numeric.decimal.carbon",
+          "match": "\\b\\d[\\d_]*(\\.?)[\\d_]*(?:(E)([+-])([\\d_]+))?(f32|f64|i128|i16|i32|i64|i8|u128|u16|u32|u64|u8)?\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.dot.decimal.carbon"
+            },
+            "2": {
+              "name": "keyword.operator.exponent.carbon"
+            },
+            "3": {
+              "name": "keyword.operator.exponent.sign.carbon"
+            },
+            "4": {
+              "name": "constant.numeric.decimal.exponent.mantissa.carbon"
+            },
+            "5": {
+              "name": "entity.name.type.numeric.carbon"
+            }
+          }
+        },
+        {
+          "comment": "hexadecimal integers",
+          "name": "constant.numeric.hex.carbon",
+          "match": "\\b0x[\\da-fA-F_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.carbon"
+            }
+          }
+        },
+        {
+          "comment": "octal integers",
+          "name": "constant.numeric.oct.carbon",
+          "match": "\\b0o[0-7_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.carbon"
+            }
+          }
+        },
+        {
+          "comment": "binary integers",
+          "name": "constant.numeric.bin.carbon",
+          "match": "\\b0b[01_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.carbon"
+            }
+          }
+        },
+        {
+          "comment": "booleans",
+          "name": "constant.language.bool.carbon",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    },
+    "escapes": {
+      "comment": "escapes: ASCII, byte, Unicode, quote, regex",
+      "name": "constant.character.escape.carbon",
+      "match": "(\\\\)(?:(?:(x[0-7][0-7a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
+      "captures": {
+        "1": {
+          "name": "constant.character.escape.backslash.carbon"
+        },
+        "2": {
+          "name": "constant.character.escape.bit.carbon"
+        },
+        "3": {
+          "name": "constant.character.escape.unicode.carbon"
+        },
+        "4": {
+          "name": "constant.character.escape.unicode.punctuation.carbon"
+        },
+        "5": {
+          "name": "constant.character.escape.unicode.punctuation.carbon"
+        }
+      }
+    },
+    "functions": {
+      "patterns": [
+        {
+          "comment": "function definition",
+          "name": "meta.function.definition.carbon",
+          "begin": "\\b(fn)\\s+((?:r#(?!crate|[Ss]elf|super))?[A-Za-z0-9_]+)((\\()|(<))",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.fn.carbon"
+            },
+            "2": {
+              "name": "entity.name.function.carbon"
+            },
+            "4": {
+              "name": "punctuation.brackets.round.carbon"
+            },
+            "5": {
+              "name": "punctuation.brackets.angle.carbon"
+            }
+          },
+          "end": "\\{|;",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.curly.carbon"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "comment": "function/method calls, chaining",
+          "name": "meta.function.call.carbon",
+          "begin": "((?:r#(?![Ss]elf|super))?[A-Za-z0-9_]+)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.carbon"
+            },
+            "2": {
+              "name": "punctuation.brackets.round.carbon"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.carbon"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#lifetimes"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "comment": "function/method calls with turbofish",
+          "name": "meta.function.call.carbon",
+          "begin": "((?:r#(?![Ss]elf|super))?[A-Za-z0-9_]+)(?=::<.*>\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.carbon"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.carbon"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#gtypes"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#lifetimes"
+            },
+            {
+              "include": "#macros"
+            },
+            {
+              "include": "#namespaces"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "comment": "control flow keywords",
+          "name": "keyword.control.carbon",
+          "match": "\\b(break|continue|do|else|for|if|loop|match|return|while)\\b"
+        },
+        {
+          "comment": "storage keywords",
+          "name": "keyword.other.carbon storage.type.carbon",
+          "match": "\\b(var|let)\\b"
+        },
+        {
+          "comment": "const keyword",
+          "name": "storage.modifier.carbon",
+          "match": "\\b(const)\\b"
+        },
+        {
+          "comment": "enum keyword",
+          "name": "keyword.declaration.enum.carbon storage.type.carbon",
+          "match": "\\b(enum)\\b"
+        },
+        {
+          "comment": "struct keyword",
+          "name": "keyword.declaration.struct.carbon storage.type.carbon",
+          "match": "\\b(struct)\\b"
+        },
+        {
+          "comment": "storage modifiers",
+          "name": "storage.modifier.carbon",
+          "match": "\\b(abstract|static)\\b"
+        },
+        {
+          "comment": "fn",
+          "name": "keyword.other.fn.carbon",
+          "match": "\\bfn\\b"
+        },
+        {
+          "comment": "logical operators",
+          "name": "keyword.operator.logical.carbon",
+          "match": "(\\^|\\||\\|\\||&&|<<|>>|!)(?!=)"
+        },
+        {
+          "comment": "assignment operators",
+          "name": "keyword.operator.assignment.carbon",
+          "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)"
+        },
+        {
+          "comment": "single equal",
+          "name": "keyword.operator.assignment.equal.carbon",
+          "match": "(?<![<>])=(?!=|>)"
+        },
+        {
+          "comment": "comparison operators",
+          "name": "keyword.operator.comparison.carbon",
+          "match": "(=(=)?(?!>)|!=|<=|(?<!=)>=)"
+        },
+        {
+          "comment": "math operators",
+          "name": "keyword.operator.math.carbon",
+          "match": "(([+%]|(\\*(?!\\w)))(?!=))|(-(?!>))|(/(?!/))"
+        },
+        {
+          "comment": "less than, greater than (special case)",
+          "match": "(?:\\b|(?:(\\))|(\\])|(\\})))[ \\t]+([<>])[ \\t]+(?:\\b|(?:(\\()|(\\[)|(\\{)))",
+          "captures": {
+            "1": {
+              "name": "punctuation.brackets.round.carbon"
+            },
+            "2": {
+              "name": "punctuation.brackets.square.carbon"
+            },
+            "3": {
+              "name": "punctuation.brackets.curly.carbon"
+            },
+            "4": {
+              "name": "keyword.operator.comparison.carbon"
+            },
+            "5": {
+              "name": "punctuation.brackets.round.carbon"
+            },
+            "6": {
+              "name": "punctuation.brackets.square.carbon"
+            },
+            "7": {
+              "name": "punctuation.brackets.curly.carbon"
+            }
+          }
+        },
+        {
+          "comment": "namespace operator",
+          "name": "keyword.operator.namespace.carbon",
+          "match": "::"
+        },
+        {
+          "comment": "dereference asterisk",
+          "match": "(\\*)(?=\\w+)",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.dereference.carbon"
+            }
+          }
+        },
+        {
+          "comment": "dot access",
+          "name": "keyword.operator.access.dot.carbon",
+          "match": "\\.(?!\\.)"
+        },
+        {
+          "comment": "ranges, range patterns",
+          "name": "keyword.operator.range.carbon",
+          "match": "\\.{2}(=|\\.)?"
+        }
+      ]
+    },
+    "interpolations": {
+      "comment": "curly brace interpolations",
+      "name": "meta.interpolation.carbon",
+      "match": "({)[^\"{}]*(})",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.interpolation.carbon"
+        },
+        "2": {
+          "name": "punctuation.definition.interpolation.carbon"
+        }
+      }
+    },
+    "namespaces": {
+      "patterns": [
+        {
+          "comment": "namespace (non-type, non-function path segment)",
+          "match": "(?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)",
+          "captures": {
+            "1": {
+              "name": "entity.name.namespace.carbon"
+            },
+            "2": {
+              "name": "keyword.operator.namespace.carbon"
+            }
+          }
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "comment": "numeric types",
+          "match": "(?<![A-Za-z])(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.numeric.carbon"
+            }
+          }
+        },
+        {
+          "comment": "parameterized types",
+          "begin": "\\b([A-Z][A-Za-z0-9]*)(<)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.type.carbon"
+            },
+            "2": {
+              "name": "punctuation.brackets.angle.carbon"
+            }
+          },
+          "end": ">",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.angle.carbon"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#block-comments"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#lvariables"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "comment": "primitive types",
+          "name": "entity.name.type.primitive.carbon",
+          "match": "\\b(bool|char)\\b"
+        },
+        {
+          "comment": "struct declarations",
+          "match": "\\b(struct)\\s+([A-Z][A-Za-z0-9]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.struct.carbon storage.type.carbon"
+            },
+            "2": {
+              "name": "entity.name.type.struct.carbon"
+            }
+          }
+        },
+        {
+          "comment": "enum declarations",
+          "match": "\\b(enum)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.enum.carbon storage.type.carbon"
+            },
+            "2": {
+              "name": "entity.name.type.enum.carbon"
+            }
+          }
+        },
+        {
+          "comment": "type declarations",
+          "match": "\\b(type)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.type.carbon storage.type.carbon"
+            },
+            "2": {
+              "name": "entity.name.type.declaration.carbon"
+            }
+          }
+        },
+        {
+          "comment": "types",
+          "name": "entity.name.type.carbon",
+          "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "comment": "comma",
+          "name": "punctuation.comma.carbon",
+          "match": ","
+        },
+        {
+          "comment": "curly braces",
+          "name": "punctuation.brackets.curly.carbon",
+          "match": "[{}]"
+        },
+        {
+          "comment": "parentheses, round brackets",
+          "name": "punctuation.brackets.round.carbon",
+          "match": "[()]"
+        },
+        {
+          "comment": "semicolon",
+          "name": "punctuation.semi.carbon",
+          "match": ";"
+        },
+        {
+          "comment": "square brackets",
+          "name": "punctuation.brackets.square.carbon",
+          "match": "[\\[\\]]"
+        },
+        {
+          "comment": "angle brackets",
+          "name": "punctuation.brackets.angle.carbon",
+          "match": "(?<!=)[<>]"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "comment": "double-quoted strings and byte strings",
+          "name": "string.quoted.double.carbon",
+          "begin": "(b?)(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.carbon"
+            },
+            "2": {
+              "name": "punctuation.definition.string.carbon"
+            }
+          },
+          "end": "\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.carbon"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#escapes"
+            },
+            {
+              "include": "#interpolations"
+            }
+          ]
+        },
+        {
+          "comment": "double-quoted raw strings and raw byte strings",
+          "name": "string.quoted.double.carbon",
+          "begin": "(b?r)(#*)(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.carbon"
+            },
+            "2": {
+              "name": "punctuation.definition.string.raw.carbon"
+            },
+            "3": {
+              "name": "punctuation.definition.string.carbon"
+            }
+          },
+          "end": "(\")(\\2)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.carbon"
+            },
+            "2": {
+              "name": "punctuation.definition.string.raw.carbon"
+            }
+          }
+        },
+        {
+          "comment": "characters and bytes",
+          "name": "string.quoted.single.char.carbon",
+          "begin": "(b)?(')",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.byte.raw.carbon"
+            },
+            "2": {
+              "name": "punctuation.definition.char.carbon"
+            }
+          },
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.char.carbon"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#escapes"
+            }
+          ]
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "comment": "variables",
+          "name": "variable.other.carbon",
+          "match": "\\b(?<!(?<!\\.)\\.)(?:r#(?!(crate|[Ss]elf|super)))?[a-z0-9_]+\\b"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
many thing are directly copied from rust lang. It gives good highlighting, but due to lack of info and guidance, I made and copied many things from dart and rust vscode extension